### PR TITLE
bugfix: Remove unsound RefCell

### DIFF
--- a/src/win32.rs
+++ b/src/win32.rs
@@ -371,7 +371,7 @@ impl Menu {
             &mut self.data,
             HashMap::with_hasher(ahash::RandomState::new()),
         );
-        let data = Box::into_raw(Box::new(RefCell::new(data)));
+        let data = Box::into_raw(Box::new(data));
         SetWindowSubclass(hwnd, Some(menu_subclass_proc), SUBCLASS_ID, data as _);
 
         Ok(())


### PR DESCRIPTION
Took a gander at my Win32 implementation and it looks like I accidentally added an unsound cast. Whoops! Fixed that.